### PR TITLE
Add station lat/long

### DIFF
--- a/nsw_fuel/dto.py
+++ b/nsw_fuel/dto.py
@@ -66,7 +66,7 @@ class Station(object):
             brand=data['brand'],
             code=int(data['code']),
             name=data['name'],
-            address=data['address']
+            address=data['address'],
             latitude=data['location']['latitude'],
             longitude=data['location']['longitude'],
         )

--- a/nsw_fuel/dto.py
+++ b/nsw_fuel/dto.py
@@ -50,12 +50,14 @@ class Price(object):
 
 class Station(object):
     def __init__(self, id: Optional[str], brand: str, code: int,
-                 name: str, address: str) -> None:
+            name: str, address: str, latitude: float, longitude: float) -> None:
         self.id = id
         self.brand = brand
         self.code = code
         self.name = name
         self.address = address
+        self.latitude = latitude
+        self.longitude = longitude
 
     @classmethod
     def deserialize(cls, data: Dict[str, Any]) -> 'Station':
@@ -65,11 +67,13 @@ class Station(object):
             code=int(data['code']),
             name=data['name'],
             address=data['address']
+            latitude=data['location']['latitude'],
+            longitude=data['location']['longitude'],
         )
 
     def __repr__(self) -> str:
-        return '<Station id={} code={} brand={} name={}>'.format(
-            self.id, self.code, self.brand, self.name)
+        return '<Station id={} code={} brand={} name={} latitude={} longitude={}>'.format(
+            self.id, self.code, self.brand, self.name, self.latitude, self.longitude)
 
 
 class Period(Enum):

--- a/nsw_fuel_tests/unit.py
+++ b/nsw_fuel_tests/unit.py
@@ -149,6 +149,8 @@ class FuelCheckClientTest(unittest.TestCase):
         )
         self.assertEqual(len(result), 3)
         self.assertEqual(result[0].station.code, 678)
+        self.assertAlmostEqual(result[0].station.latitude, -33.987)
+        self.assertAlmostEqual(result[0].station.longitude, 151.334)
         self.assertEqual(result[0].price.price, 150.9)
 
     @Mocker()

--- a/nsw_fuel_tests/unit.py
+++ b/nsw_fuel_tests/unit.py
@@ -28,6 +28,8 @@ class FuelCheckClientTest(unittest.TestCase):
             self.assertEqual(len(response.prices), 5)
             self.assertEqual(response.stations[0].name, 'Cool Fuel Brand Hurstville')
             self.assertEqual(response.stations[1].name, 'Fake Fuel Brand Kogarah')
+            self.assertAlmostEqual(response.stations[1].latitude, -31)
+            self.assertAlmostEqual(response.stations[1].longitude, 152)
             self.assertEqual(response.prices[0].fuel_type, 'DL')
             self.assertEqual(response.prices[1].fuel_type, 'E10')
             self.assertEqual(response.prices[1].station_code, 1)
@@ -89,7 +91,7 @@ class FuelCheckClientTest(unittest.TestCase):
                     'code': 678,
                     'name': 'Cool Fuel Brand Luxembourg',
                     'address': '123 Fake Street',
-                    'location': {},
+                    'location': {'latitude': -33.987, 'longitude': 151.334},
                 },
                 {
                     'stationid': 'SAAAAAB',
@@ -98,7 +100,7 @@ class FuelCheckClientTest(unittest.TestCase):
                     'code': 679,
                     'name': 'Fake Fuel Brand Luxembourg',
                     'address': '123 Fake Street',
-                    'location': {},
+                    'location': {'latitude': -33.587, 'longitude': 151.434},
                 },
                 {
                     'stationid': 'SAAAAAB',
@@ -107,7 +109,7 @@ class FuelCheckClientTest(unittest.TestCase):
                     'code': 880,
                     'name': 'Fake Fuel Brand2 Luxembourg',
                     'address': '123 Fake Street',
-                    'location': {},
+                    'location': {'latitude': -33.687, 'longitude': 151.234},
                 },
             ],
             'prices': [


### PR DESCRIPTION
Extracts the lat/long from the returned json data. Useful for things such as proximity to stations, etc.
